### PR TITLE
Input Validation for CFN AmazonConnectInstanceId

### DIFF
--- a/deployment/voicemail-for-amazon-connect.template
+++ b/deployment/voicemail-for-amazon-connect.template
@@ -25,9 +25,9 @@ Description: (SO0094) - Solution - Master Template - This template creates all t
 
 Parameters:
     AmazonConnectInstanceId:
-      Default: ""
       Type: String
       Description: Your Amazon Connect Instance Id
+      AllowedPattern: ^([0-9a-f]){8}-([0-9a-f]){4}-([0-9a-f]){4}-([0-9a-f]){4}-([0-9a-f]){12}$
     AvailableSMSCountries:
       Default: "us,ca"
       Type: String


### PR DESCRIPTION
Customers can input entire ARN in the AmazonConnectInstanceId parameter, causing silent errors after deployment

*Description of changes:
added input validation to allow only guid's to be input i.e. Connect Instance IDs


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
