### PR TITLE
Support for non E-Mail formatted Usernames (SAML)

### DIFF
--- a/source/aws-connect-vm-serverless/src/domain/agent.domain.js
+++ b/source/aws-connect-vm-serverless/src/domain/agent.domain.js
@@ -17,6 +17,7 @@ class Agent {
         this.userId = agentMap["userId"];
         this.extension = agentMap["extension"];
         this.username = agentMap["username"];
+        this.email = agentMap["email"];
         this.transcribeVoicemail = agentMap["transcribeVoicemail"] || false;
         this.encryptVoicemail = agentMap["encryptVoicemail"] || false;
         this.deliveryOptions = agentMap["deliveryOptions"] || {
@@ -28,9 +29,9 @@ class Agent {
         };
     }
 
-    static create(userId, extension = null) {
+    static create(userId, extension = null, email = null) {
         return new Agent({
-            userId, extension: extension, deliveryOptions: {
+            userId, extension: extension, email: email, deliveryOptions: {
                 sms: {
                     enabled: false,
                     phoneNumber: null

--- a/source/aws-connect-vm-serverless/src/service/notification.service.js
+++ b/source/aws-connect-vm-serverless/src/service/notification.service.js
@@ -53,7 +53,7 @@ class NotificationService {
         let deliveryOptions = connectAgent.agent.deliveryOptions;
         let shouldSendEmail = deliveryOptions.email;
         let shouldSendSMS = deliveryOptions.sms.enabled;
-        let contactEmail = connectAgent.connectUser.email || connectAgent.connectUser.username; // For SSO instances
+        let contactEmail = connectAgent.agent.email || connectAgent.connectUser.email || connectAgent.connectUser.username; // For SSO instances
         let agentSMSPhoneNumber = deliveryOptions.sms.phoneNumber;
         let deliveryEmail = globalSettings.deliveryEmail;
 

--- a/source/aws-connect-vm-serverless/tests/agent.test.js
+++ b/source/aws-connect-vm-serverless/tests/agent.test.js
@@ -16,7 +16,8 @@ test('Get Agent By Extension', async () => {
     const agentResponse = new Agent({
         "userId": "userId",
         "extension": extension,
-        "username": "username"
+        "username": "username",
+        "email": "email"
     });
     const connectUserResponse = new ConnectUser({
         "Id": userId,
@@ -63,7 +64,8 @@ test('Get Agent By Id', async () => {
     const agentResponse = new Agent({
         "userId": userId,
         "extension": "1234",
-        "username": "username"
+        "username": "username",
+        "email": "email"
     });
     
     const mockGetConnectUser = jest.fn();
@@ -98,7 +100,8 @@ test('Sync Connect Agents - No Update Needed', async () => {
     const ddbUsersResponse = [{
         "userId": userId,
         "extension": "1234",
-        "username": "username"
+        "username": "username",
+        "email": "email"
     }];
     const connectUsersResponse = [{
         "Id": userId,
@@ -162,7 +165,8 @@ test('Update Agent By Id', async () => {
         "deliverSMS": "deliverSMS",
         "deliverEmail": "deliverEmail",
         "transcribeVoicemail": true,
-        "encryptVoicemail": true
+        "encryptVoicemail": true,
+        "email": "email"
     };
     const connectUserResponse = new ConnectUser({
         "Id": userId,
@@ -204,7 +208,8 @@ test('Update Agent By Id - Create Agent', async () => {
         "deliverSMS": "deliverSMS",
         "deliverEmail": "deliverEmail",
         "transcribeVoicemail": true,
-        "encryptVoicemail": true
+        "encryptVoicemail": true,
+        "email": "email"
     };
     const connectUserResponse = new ConnectUser({
         "Id": userId,
@@ -221,7 +226,8 @@ test('Update Agent By Id - Create Agent', async () => {
     const agentResponse = new Agent({
         "userId": userId,
         "extension": "1234",
-        "username": "username"
+        "username": "username",
+        "email": "email"
     });
 
     const mockGetById = jest.fn();

--- a/source/aws-connect-vm-serverless/tests/env.js
+++ b/source/aws-connect-vm-serverless/tests/env.js
@@ -3,16 +3,16 @@
  */
 function loadEnvironment() {
     console.log("Loading Environment");
-    process.env.AWS_REGION = "iad";
-    process.env.TRANSCRIBE_REGION = "iad";
+    process.env.AWS_REGION = "us-east-1";
+    process.env.TRANSCRIBE_REGION = "us-east-1";
     process.env.STAGE = "prod";
-    process.env.AMAZON_CONNECT_INSTANCE_ARN = "arn:aws:connect:us-west-2:123456789012:instance/aadc335a-9bfd-46c2-b0d1-7fcc365a56b4";
-    process.env.USERS_TABLE_NAME = `prod-Users`;
-    process.env.CONNECT_USER_STS_ROLE_ARN = "arn:aws:iam::123456789012:role/aws-connect-vm-api-ConnectUserStsRole-Z4YQND6VSXSF";
-    process.env.CONTACT_VOICEMAIL_TABLE_NAME = `prod-ContactVoicemail`;
-    process.env.COGNITO_USER_POOL_ID = `us-east-1_TlZLQppMm`;
-    process.env.COGNITO_APP_CLIENT_ID = `46sv1tgl2v0opb94fdhmd9ffxs`;
-    process.env.GET_AGENT_BY_EXTENSION_LAMBDA_ARN = `arn:aws:lambda:iad:123456789012:function:aws-connect-vm-api-iad-get-agent-by-extension`;
+    process.env.AMAZON_CONNECT_INSTANCE_ARN = "arn:aws:connect:us-east-1:xxx:instance/xxx";
+    process.env.USERS_TABLE_NAME = `xxx-VoicemailStack-xxx-UsersTable-xxx`;
+    /**process.env.CONNECT_USER_STS_ROLE_ARN = "xxx";*/
+    process.env.CONTACT_VOICEMAIL_TABLE_NAME = `xxx-VoicemailStack-xxx-ContactVoicemailTable-xxx`;
+    process.env.COGNITO_USER_POOL_ID = `us-east-1_xxx`;
+    process.env.COGNITO_APP_CLIENT_ID = `UserPoolClient-xxx`;
+    process.env.GET_AGENT_BY_EXTENSION_LAMBDA_ARN = `arn:aws:lambda:us-east-1:xxx:function:xxx-VoicemailStack-GetAgentByExtensionLambd-xxx`;
 }
 
 export {loadEnvironment}


### PR DESCRIPTION
*Issue #, if available:*

N/A

*Description of changes:*

Added support for SAML based Amazon Connect implementations where the username is NOT an E-Mail Address.

Checks Users Table for email attribute and uses value.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

Confirmed