### PR TITLE
S3 regional domain name value to support non us-east-1 deployments #47

### DIFF
--- a/deployment/voicemail-for-amazon-connect.template
+++ b/deployment/voicemail-for-amazon-connect.template
@@ -270,7 +270,7 @@ Resources:
           UserPoolArn: !GetAtt VoicemailStack.Outputs.UserPoolArn
           SolutionHelperFunctionArn: !GetAtt SolutionHelperFunction.Arn
           PortalBucket: !Ref PortalBucket
-          PortalBucketDomainName: !GetAtt PortalBucket.DomainName
+          PortalBucketDomainName: !GetAtt PortalBucket.RegionalDomainName
           PortalBucketArn: !GetAtt PortalBucket.Arn
  
     PortalBucket:


### PR DESCRIPTION
Issue #47 

Replacement of S3 domain name value with regional domain name value to support deployments outside of us-east-1.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
