### PR TITLE
Improved handling of many users in Amazon Connect

### DIFF
--- a/source/aws-connect-vm-serverless/src/lib/dynamo.js
+++ b/source/aws-connect-vm-serverless/src/lib/dynamo.js
@@ -44,10 +44,22 @@ class DynamoDBService {
         return this.client.query(params).promise().then(result => result.Items || null);
     }
 
-    scan(params) {
+    scan(params, items = []) {
         params["TableName"] = this.tableName;
         return this.client.scan(params).promise().then(result => {
-            return result.Items || null
+
+            let allItems = items;
+
+            if (result.Items) {
+                allItems = items.concat(result.Items);
+            }
+            if (result.LastEvaluatedKey){
+                console.log("Rescanning with next page");
+                params.ExclusiveStartKey = result.LastEvaluatedKey;
+                return this.scan(params, allItems);
+            } else {
+                return allItems;
+            }
         });
     }
 

--- a/source/aws-connect-vm-serverless/src/service/connect.service.js
+++ b/source/aws-connect-vm-serverless/src/service/connect.service.js
@@ -23,7 +23,7 @@ class ConnectService {
         this.connect = new AWS.Connect();
 
         // max backoff time set to 30 sec
-        this.maxBackOffTime = 30;
+        this.maxBackOffTime = 45;
     }
 
 
@@ -73,7 +73,7 @@ class ConnectService {
     _listConnectUsers(list, nextToken, retry) {
         let params = {
             InstanceId: this.instanceId,
-            MaxResults: 100
+            MaxResults: 1000
         };
         if (nextToken) {
             params["NextToken"] = nextToken;


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/amazon-connect/voicemail-for-amazon-connect/issues/51

*Description of changes:*
Changed MaxResults to 1000 and maxBackOffTime to 45 sec to reduce the chance of rate limiting when syncing lots of users from Connect via ListUsers API. Modified scan() in dynamo.js so that more than 1 MB of items can be returned from the Users table.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
